### PR TITLE
Allow '-' char in name of typeface, rather than replacing it with a spac...

### DIFF
--- a/core/actions/header-actions.php
+++ b/core/actions/header-actions.php
@@ -50,7 +50,7 @@ function response_font() {
 		$font = $options->get($themeslug.'_font'); 
 	} ?>
 	
-	<body style="font-family:'<?php echo ereg_replace("[^A-Za-z0-9]", " ", $font ); ?>', <?php echo $family; ?>" <?php body_class(); ?> > <?php
+	<body style="font-family:'<?php echo ereg_replace("[^-A-Za-z0-9]", " ", $font ); ?>', <?php echo $family; ?>" <?php body_class(); ?> > <?php
 }
 
 /**


### PR DESCRIPTION
...e char.

Current filter translates "invalid" characters in a typeface (font) name to ' ', restricting "valid" chars to alpha-numeric+space, only; but '-' is a common typeface name. In particular, TypeKit generates names with '-'s. This change allows '-'s.
