### PR TITLE
 Allow '-' char in name of typeface name.

### DIFF
--- a/core/actions/header-actions.php
+++ b/core/actions/header-actions.php
@@ -50,7 +50,7 @@ function response_font() {
 		$font = $options->get($themeslug.'_font'); 
 	} ?>
 	
-	<body style="font-family:'<?php echo ereg_replace("[^A-Za-z0-9]", " ", $font ); ?>', <?php echo $family; ?>" <?php body_class(); ?> > <?php
+	<body style="font-family:'<?php echo ereg_replace("[^A-Za-z0-9\-]", " ", $font ); ?>', <?php echo $family; ?>" <?php body_class(); ?> > <?php
 }
 
 /**

--- a/core/pro/actions/header-actions.php
+++ b/core/pro/actions/header-actions.php
@@ -37,7 +37,7 @@ function response_pro_font() {
 		$font = $options->get($themeslug.'_font'); 
 	} ?>
 	
-	<body style="font-family:'<?php echo ereg_replace("[^-A-Za-z0-9]", " ", $font ); ?>', <?php echo $family; ?>" <?php body_class(); ?> > <?php
+	<body style="font-family:'<?php echo ereg_replace("[^A-Za-z0-9\-]", " ", $font ); ?>', <?php echo $family; ?>" <?php body_class(); ?> > <?php
 }
 
 /**

--- a/core/pro/actions/header-actions.php
+++ b/core/pro/actions/header-actions.php
@@ -37,7 +37,7 @@ function response_pro_font() {
 		$font = $options->get($themeslug.'_font'); 
 	} ?>
 	
-	<body style="font-family:'<?php echo ereg_replace("[^A-Za-z0-9]", " ", $font ); ?>', <?php echo $family; ?>" <?php body_class(); ?> > <?php
+	<body style="font-family:'<?php echo ereg_replace("[^-A-Za-z0-9]", " ", $font ); ?>', <?php echo $family; ?>" <?php body_class(); ?> > <?php
 }
 
 /**

--- a/includes/options-functions.php
+++ b/includes/options-functions.php
@@ -189,7 +189,7 @@ function add_menu_font() {
 		$font = $options->get($themeslug.'_menu_font'); 
 	}
 	
-		$fontstrip =  ereg_replace("[^A-Za-z0-9]", " ", $font );
+		$fontstrip =  ereg_replace("[^A-Za-z0-9\-]", " ", $font );
 	
 		if( $font == 'Actor' ||
 			$font == 'Coda' ||
@@ -226,7 +226,7 @@ function add_secondary_font() {
 		$font = $options->get($themeslug.'_secondary_font'); 
 	}
 	
-		$fontstrip =  ereg_replace("[^A-Za-z0-9]", " ", $font );
+		$fontstrip =  ereg_replace("[^A-Za-z0-9\-]", " ", $font );
 	
 		if( $font == 'Actor' ||
 			$font == 'Coda' ||


### PR DESCRIPTION
Current filter translates "invalid" characters in a typeface (font) name to ' ', restricting "valid" chars to alpha-numeric+space, only; but '-' is a common typeface name. In particular, TypeKit generates names with '-'s. This change allows '-'s.

A more complete solution. Sorry, still learning how to make changes to repos that I don't have access to, or I would have done this "properly," before. 
